### PR TITLE
Bump version to 1.2.7 to fix PyPI package metadata

### DIFF
--- a/purl2notices/__init__.py
+++ b/purl2notices/__init__.py
@@ -1,6 +1,6 @@
 """purl2notices - Generate legal notices for software packages."""
 
-__version__ = "1.2.6"
+__version__ = "1.2.7"
 __author__ = "Oscar Valenzuela B"
 __email__ = "oscar.valenzuela.b@gmail.com"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "purl2notices"
-version = "1.2.6"
+version = "1.2.7"
 description = "Generate legal notices (attribution to authors and copyrights) for software packages"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
## Summary

- Bumps version from 1.2.6 to 1.2.7 to allow republishing with correct dependency metadata
- Fixes PyPI package metadata issue where v1.2.6 references non-existent purl2src>=1.2.5

## Background

The published PyPI package `purl2notices 1.2.6` contains incorrect dependency metadata:
- **Published metadata**: `Requires-Dist: purl2src>=1.2.5` ❌ (version doesn't exist)
- **Repository code**: `purl2src>=1.2.3` ✅ (correct)

**Timeline:**
- October 30, 2025 (commit a337d13): Dependency changed to purl2src>=1.2.5 (non-existent)
- Same day: Version 1.2.6 published to PyPI with broken metadata
- November 3, 2025 (commit 99cc4f5): Repository fixed to use purl2src>=1.2.3
- **Issue**: PyPI package 1.2.6 still has broken metadata

## Changes

- Updated version in `pyproject.toml` from 1.2.6 to 1.2.7
- Updated version in `purl2notices/__init__.py` from 1.2.6 to 1.2.7
- Dependency already correctly set to `purl2src>=1.2.3`

## Test plan

- [ ] Verify version is correctly set to 1.2.7 in both files
- [ ] Build the package and verify metadata contains `purl2src>=1.2.3`
- [ ] Publish to PyPI
- [ ] Test installation: `pip install purl2notices==1.2.7`