### PR TITLE
Write text files as UTF-8 regardless of platform locale (fixes #20)

### DIFF
--- a/purl2notices/cache.py
+++ b/purl2notices/cache.py
@@ -29,7 +29,7 @@ class CacheManager:
             return []
         
         try:
-            with open(self.cache_file, 'r') as f:
+            with open(self.cache_file, 'r', encoding='utf-8') as f:
                 data = json.load(f)
             
             if data.get('bomFormat') != CACHE_FORMAT:
@@ -62,7 +62,7 @@ class CacheManager:
             # Ensure directory exists
             self.cache_file.parent.mkdir(parents=True, exist_ok=True)
             
-            with open(self.cache_file, 'w') as f:
+            with open(self.cache_file, 'w', encoding='utf-8') as f:
                 json.dump(bom, f, indent=2)
         except Exception as e:
             logger.warning(f"Failed to save cache: {e}")

--- a/purl2notices/cli.py
+++ b/purl2notices/cli.py
@@ -477,7 +477,7 @@ def main(
         has_errors = no_license_packages or failed_packages or non_oss_packages
         
         if has_errors:
-            with open(error_log_file, 'w') as f:
+            with open(error_log_file, 'w', encoding='utf-8') as f:
                 f.write(f"=== purl2notices Error Log - {datetime.now().isoformat()} ===\n\n")
                 
                 if failed_packages:
@@ -536,7 +536,7 @@ def main(
         if output:
             output_path = Path(output)
             output_path.parent.mkdir(parents=True, exist_ok=True)
-            with open(output_path, 'w') as f:
+            with open(output_path, 'w', encoding='utf-8') as f:
                 f.write(notices)
             logger.info(f"Legal notices written to: {output}")
         else:

--- a/purl2notices/config.py
+++ b/purl2notices/config.py
@@ -87,7 +87,7 @@ class Config:
     def load_config(self, config_file: Path) -> None:
         """Load configuration from file."""
         try:
-            with open(config_file, 'r') as f:
+            with open(config_file, 'r', encoding='utf-8') as f:
                 user_config = yaml.safe_load(f)
                 if user_config:
                     self._merge_config(self.config, user_config)

--- a/purl2notices/detectors/gem.py
+++ b/purl2notices/detectors/gem.py
@@ -148,7 +148,7 @@ class GemDetector(BaseDetector):
         try:
             import json
 
-            with open(metadata_file, 'r') as f:
+            with open(metadata_file, 'r', encoding='utf-8') as f:
                 data = json.load(f)
 
             name = data.get('name')

--- a/purl2notices/overrides.py
+++ b/purl2notices/overrides.py
@@ -30,7 +30,7 @@ class OverrideManager:
             }
         
         try:
-            with open(self.override_file, 'r') as f:
+            with open(self.override_file, 'r', encoding='utf-8') as f:
                 return json.load(f)
         except Exception as e:
             logger.warning(f"Failed to load overrides from {self.override_file}: {e}")
@@ -39,7 +39,7 @@ class OverrideManager:
     def save_overrides(self) -> None:
         """Save overrides to file."""
         try:
-            with open(self.override_file, 'w') as f:
+            with open(self.override_file, 'w', encoding='utf-8') as f:
                 json.dump(self.overrides, f, indent=2, sort_keys=True)
         except Exception as e:
             logger.error(f"Failed to save overrides to {self.override_file}: {e}")

--- a/purl2notices/scanner.py
+++ b/purl2notices/scanner.py
@@ -294,7 +294,7 @@ class PackageScanner:
     def _process_package_json(self, path: Path) -> Optional[Package]:
         """Process package.json file."""
         try:
-            with open(path, 'r') as f:
+            with open(path, 'r', encoding='utf-8') as f:
                 data = json.load(f)
             
             name = data.get('name', '')

--- a/purl2notices/validators.py
+++ b/purl2notices/validators.py
@@ -98,7 +98,7 @@ class FileValidator:
             return False, [], f"Not a file: {file_path}"
         
         try:
-            with open(file_path, 'r') as f:
+            with open(file_path, 'r', encoding='utf-8') as f:
                 lines = f.readlines()
             
             purls = []
@@ -137,7 +137,7 @@ class FileValidator:
         if file_path.suffix == '.json' or file_path.name.endswith('.cdx.json') or file_path.name.endswith('.cache.json'):
             try:
                 import json
-                with open(file_path, 'r') as f:
+                with open(file_path, 'r', encoding='utf-8') as f:
                     data = json.load(f)
                     # Check for CycloneDX structure
                     return 'bomFormat' in data and data['bomFormat'] == 'CycloneDX'

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -146,6 +146,58 @@ class TestCLI:
             assert result.exit_code == 0
             assert '<html>' in result.output or '<!DOCTYPE' in result.output
     
+    def test_cli_html_output_file_non_ascii_locale(self, monkeypatch):
+        """Regression test for #20: HTML notices must be written as UTF-8
+        regardless of the platform's default text encoding.
+
+        On Windows the default text encoding is cp1252, which cannot encode
+        characters such as U+2191 that appear in the HTML template, so writing
+        the output file used to crash with a UnicodeEncodeError. Here we force
+        a cp1252 default for encoding-less text opens to reproduce that
+        environment and assert the output is still written correctly.
+        """
+        import builtins
+
+        real_open = builtins.open
+
+        def cp1252_default_open(file, mode='r', *args, **kwargs):
+            if 'b' not in mode and 'encoding' not in kwargs:
+                kwargs['encoding'] = 'cp1252'
+            return real_open(file, mode, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, 'open', cp1252_default_open)
+
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            cache = Path('test.cache.json')
+            cache_data = {
+                "bomFormat": "CycloneDX",
+                "specVersion": "1.6",
+                "components": [
+                    {
+                        "type": "library",
+                        "name": "express",
+                        "version": "4.18.0",
+                        "purl": "pkg:npm/express@4.18.0",
+                        "licenses": [{"license": {"id": "MIT"}}]
+                    }
+                ]
+            }
+            cache.write_text(json.dumps(cache_data), encoding='utf-8')
+
+            output_file = Path('express.html')
+
+            result = runner.invoke(main, [
+                '--input', str(cache),
+                '--output', str(output_file),
+                '--format', 'html'
+            ])
+
+            assert result.exit_code == 0, result.output
+            assert output_file.exists()
+            content = output_file.read_text(encoding='utf-8')
+            assert '<html' in content.lower() or '<!doctype' in content.lower()
+
     def test_cli_json_format(self):
         """Test JSON output format (to be implemented)."""
         runner = CliRunner()


### PR DESCRIPTION
## Problem

Generating HTML notices on Windows crashes:

```
purl2notices -i pkg:npm/express@4.0.0 -o express.html -f html
UnicodeEncodeError: 'charmap' codec can't encode character '↑' in position 4789: character maps to <undefined>
```

The text-mode `open()` calls did not specify an encoding, so Python fell back to the platform default. On Windows that default is cp1252, which cannot encode some of the characters in the generated notices (for example the U+2191 arrow that comes from the HTML template). TXT output only appeared to work because that particular content happened to stay inside the cp1252 range, so it was the same latent bug either way.

## Fix

Pass `encoding='utf-8'` explicitly to every text-mode `open()` in the codebase. That covers the reported output write and also the reads and writes that would hit the mirror of this bug when a UTF-8 file (cache, overrides, config, or a PURL/license input) is read back on a non-UTF-8 locale. Binary opens are left alone.

Files touched: `cli.py` (output plus error log), `cache.py`, `overrides.py`, `config.py`, `scanner.py`, `validators.py`, and `detectors/gem.py`.

## Test

Added `test_cli_html_output_file_non_ascii_locale`. It monkeypatches text-mode opens so an encoding-less open defaults to cp1252, reproducing a Windows-style locale, and asserts that HTML output is still written. Without the fix it reproduces the exact `UnicodeEncodeError` on U+2191 from the report; with the fix it passes. Full suite: 76 passing.

Fixes #20
