### PR TITLE
Never emit SBOM components without a license; fall back to declared license (#30)

### DIFF
--- a/purl2notices/cache.py
+++ b/purl2notices/cache.py
@@ -199,16 +199,23 @@ class CacheManager:
             if pkg.purl:
                 component["purl"] = pkg.purl
             
-            # Add licenses
+            # Add licenses. Always emit a licenses entry so a component whose
+            # license could not be determined is explicitly marked NOASSERTION
+            # rather than left without licenses and silently dropped by
+            # downstream SBOM consumers.
+            component["licenses"] = []
             if pkg.licenses:
-                component["licenses"] = []
                 for lic in pkg.licenses:
                     license_obj = {}
                     if lic.spdx_id and lic.spdx_id != "NOASSERTION":
                         license_obj["license"] = {"id": lic.spdx_id}
-                    else:
+                    elif lic.name:
                         license_obj["license"] = {"name": lic.name}
+                    else:
+                        license_obj["license"] = {"id": "NOASSERTION"}
                     component["licenses"].append(license_obj)
+            else:
+                component["licenses"].append({"license": {"id": "NOASSERTION"}})
             
             # Add copyright as property
             if pkg.copyrights:

--- a/purl2notices/core.py
+++ b/purl2notices/core.py
@@ -3,7 +3,7 @@
 import asyncio
 import logging
 from pathlib import Path
-from typing import List, Optional, Dict
+from typing import Any, List, Optional, Dict
 
 from tqdm import tqdm
 
@@ -249,10 +249,59 @@ class Purl2Notices:
             )
             package = self._extraction_to_package(package, extraction)
             packages.append(package)
-        
+
         loop.close()
-        
+
+        # Fall back to the license declared in package metadata for any package
+        # whose content-based detection produced no license. This preserves
+        # authoritative declared licenses (e.g. the package.json "license"
+        # field) that the text classifier may fail to recognize, such as the
+        # canonical ISC text used by picocolors.
+        for package in packages:
+            self._apply_declared_license_fallback(package)
+
         return packages
+
+    @staticmethod
+    def _declared_license_id(declared: Any) -> Optional[str]:
+        """Normalize a declared license value from package metadata into an
+        SPDX identifier string, or None if it is unusable as one."""
+        if isinstance(declared, dict):
+            # npm's deprecated object form: {"type": "ISC", "url": "..."}
+            declared = declared.get('type') or declared.get('id') or ''
+        if not isinstance(declared, str):
+            return None
+        declared = declared.strip()
+        if not declared:
+            return None
+        lowered = declared.lower()
+        if lowered in ('unlicensed', 'none', 'unknown', 'noassertion') \
+                or lowered.startswith('see license'):
+            return None
+        return declared
+
+    def _apply_declared_license_fallback(self, package: Package) -> None:
+        """When content-based detection found no license, adopt the license
+        declared in package metadata so it is not lost. Never overrides a
+        detected license."""
+        if package.licenses:
+            return
+        declared = package.metadata.get('license') if package.metadata else None
+        spdx_id = self._declared_license_id(declared)
+        if not spdx_id:
+            return
+        package.licenses.append(License(
+            spdx_id=spdx_id,
+            name=spdx_id,
+            text="",
+            source="declared-metadata"
+        ))
+        # Refresh status now that a license is present.
+        if package.status == ProcessingStatus.NO_LICENSE:
+            package.status = (
+                ProcessingStatus.SUCCESS if package.copyrights
+                else ProcessingStatus.NO_COPYRIGHT
+            )
     
     def process_cache(self, cache_file: Path, override_file: Optional[Path] = None) -> List[Package]:
         """Load packages from cache file."""

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -19,6 +19,35 @@ class TestCacheManager:
         assert manager.cache_file == cache_file
         assert not cache_file.exists()
     
+    def test_component_without_license_emits_noassertion(self, temp_dir):
+        """Regression test for #30: a component whose license could not be
+        determined must still be emitted, explicitly marked NOASSERTION, so it
+        is never silently dropped from the SBOM."""
+        manager = CacheManager(temp_dir / "test.cache.json")
+        pkg = Package(name="picocolors", version="1.1.1",
+                      purl="pkg:npm/picocolors@1.1.1")
+        assert not pkg.licenses
+
+        bom = manager._create_cyclonedx([pkg])
+
+        assert len(bom["components"]) == 1
+        component = bom["components"][0]
+        assert component["name"] == "picocolors"
+        assert component["licenses"] == [{"license": {"id": "NOASSERTION"}}]
+
+    def test_component_with_nameless_license_emits_noassertion(self, temp_dir):
+        """A license with neither an SPDX id nor a name still serializes to a
+        NOASSERTION entry rather than an empty/invalid license object."""
+        manager = CacheManager(temp_dir / "test.cache.json")
+        pkg = Package(name="mystery", version="0.0.0")
+        pkg.licenses.append(License(spdx_id="", name="", text=""))
+
+        bom = manager._create_cyclonedx([pkg])
+
+        assert bom["components"][0]["licenses"] == [
+            {"license": {"id": "NOASSERTION"}}
+        ]
+
     def test_save_packages_to_cache(self, temp_dir, sample_packages):
         """Test saving packages to cache."""
         cache_file = temp_dir / "test.cache.json"

--- a/tests/unit/test_core_license_fallback.py
+++ b/tests/unit/test_core_license_fallback.py
@@ -1,0 +1,91 @@
+"""Unit tests for the declared-license fallback (issue #30)."""
+
+import pytest
+
+from purl2notices.core import Purl2Notices
+from purl2notices.config import Config
+from purl2notices.models import Package, License, Copyright, ProcessingStatus
+
+
+@pytest.fixture
+def core():
+    return Purl2Notices(Config())
+
+
+class TestDeclaredLicenseId:
+    """Normalization of declared license metadata values."""
+
+    @pytest.mark.parametrize("declared,expected", [
+        ("ISC", "ISC"),
+        ("  MIT  ", "MIT"),
+        ("(MIT OR Apache-2.0)", "(MIT OR Apache-2.0)"),
+        ({"type": "ISC", "url": "https://example.com"}, "ISC"),
+    ])
+    def test_usable_values(self, declared, expected):
+        assert Purl2Notices._declared_license_id(declared) == expected
+
+    @pytest.mark.parametrize("declared", [
+        "", "   ", None, "UNLICENSED", "unknown", "NOASSERTION",
+        "SEE LICENSE IN LICENSE", {}, {"url": "x"}, 123,
+    ])
+    def test_unusable_values(self, declared):
+        assert Purl2Notices._declared_license_id(declared) is None
+
+
+class TestDeclaredLicenseFallback:
+    """Fallback to declared license metadata when detection found none."""
+
+    def test_fills_in_declared_license_when_none_detected(self, core):
+        pkg = Package(name="picocolors", version="1.1.1",
+                      purl="pkg:npm/picocolors@1.1.1",
+                      status=ProcessingStatus.NO_LICENSE,
+                      metadata={"license": "ISC"})
+
+        core._apply_declared_license_fallback(pkg)
+
+        assert [l.spdx_id for l in pkg.licenses] == ["ISC"]
+        assert pkg.licenses[0].source == "declared-metadata"
+        # No copyright, so status moves from NO_LICENSE to NO_COPYRIGHT.
+        assert pkg.status == ProcessingStatus.NO_COPYRIGHT
+
+    def test_status_becomes_success_when_copyright_present(self, core):
+        pkg = Package(name="picocolors", version="1.1.1",
+                      status=ProcessingStatus.NO_LICENSE,
+                      metadata={"license": "ISC"})
+        pkg.copyrights.append(Copyright(statement="Copyright (c) 2024"))
+
+        core._apply_declared_license_fallback(pkg)
+
+        assert pkg.status == ProcessingStatus.SUCCESS
+
+    def test_does_not_override_detected_license(self, core):
+        pkg = Package(name="dotenv", version="16.6.1",
+                      metadata={"license": "BSD-2-Clause"})
+        pkg.licenses.append(License(spdx_id="BSD-3-Clause", name="BSD-3-Clause",
+                                    text="", source="content"))
+
+        core._apply_declared_license_fallback(pkg)
+
+        # Detected license is authoritative; declared value is not appended.
+        assert [l.spdx_id for l in pkg.licenses] == ["BSD-3-Clause"]
+
+    def test_no_op_without_declared_license(self, core):
+        pkg = Package(name="mystery", version="0.0.0",
+                      status=ProcessingStatus.NO_LICENSE, metadata={})
+
+        core._apply_declared_license_fallback(pkg)
+
+        assert pkg.licenses == []
+        assert pkg.status == ProcessingStatus.NO_LICENSE
+
+    def test_does_not_bump_unavailable_status(self, core):
+        # A package that could not be fetched keeps its UNAVAILABLE status even
+        # though we record its declared license for SBOM completeness.
+        pkg = Package(name="picocolors", version="1.1.1",
+                      status=ProcessingStatus.UNAVAILABLE,
+                      metadata={"license": "ISC"})
+
+        core._apply_declared_license_fallback(pkg)
+
+        assert [l.spdx_id for l in pkg.licenses] == ["ISC"]
+        assert pkg.status == ProcessingStatus.UNAVAILABLE


### PR DESCRIPTION
## Problem

Issue #30: when generating a CycloneDX SBOM, a component whose license text cannot be classified (for example picocolors, which is ISC) is under-reported with no warning. For a compliance tool, an SBOM that looks complete but quietly omits a dependency is the worst failure mode.

## Investigation

I reproduced the case with a minimal `node_modules` holding the six packages from the issue, then traced the pipeline:

- purl2notices does not drop the component itself. `process_directory()` returns every package (a license-less one gets `status = NO_LICENSE` and is still appended), and `cache._create_cyclonedx()` serializes all of them.
- The real problem is that a license-less component was emitted with no `licenses` field at all, rather than with `NOASSERTION`. That empty field is what lets a downstream consumer (the `mcp-semclone generate_sbom` wrapper) filter it out silently.
- The declared license was also being ignored. The npm detector already reads `package.json`'s `"license": "ISC"` into the package metadata, but the pipeline only trusted text classification and never fell back to it.

So the drop originates downstream, but purl2notices was making it possible. This change makes purl2notices defensively drop-proof.

## Changes

1. Always emit a `licenses` entry in `_create_cyclonedx`. A component with no determinable license is now marked `NOASSERTION` instead of being left with no licenses, so no downstream tool can drop it silently.
2. Declared-license fallback (`_apply_declared_license_fallback`): when content-based detection finds no license, adopt the license declared in the package metadata (for example the `package.json` `"license"` field). The value is normalized by `_declared_license_id`, which handles the deprecated object form and rejects unusable values like `UNLICENSED`, `SEE LICENSE IN ...`, and empty strings. It never overrides a detected license. This recovers picocolors to ISC directly.

## Verification

With the repro `node_modules`, picocolors was previously emitted with no `licenses`; now it carries `{"license": {"id": "ISC"}}` and every component has an explicit license.

Added regression tests: NOASSERTION emission for license-less and nameless-license components, plus declared-license normalization and fallback, covering "never override a detected license", the status transitions, and rejection of unusable values. Full suite: 96 passing.

## Out of scope

- The over-matched, invalid SPDX ids reported in #30 (`"MIT, MIT-or-later"`, `"BSD-2-Clause, BSD-3-Clause"`) and canonical ISC-text recognition live in the OSLILI classifier, not here.
- The `mcp-semclone generate_sbom` wrapper should also stop filtering components. With NOASSERTION now always present, it has an unambiguous signal to key on instead of dropping.

Addresses #30.
