### PR TITLE
Keep unlicensed packages in JSON output as NOASSERTION (#30)

### DIFF
--- a/purl2notices/formatter.py
+++ b/purl2notices/formatter.py
@@ -115,8 +115,15 @@ class NoticeFormatter:
         # Render template
         return template.render(**context)
     
-    def _filter_oss_packages(self, packages: List[Package]) -> List[Package]:
-        """Filter out packages with non-OSS licenses."""
+    def _filter_oss_packages(self, packages: List[Package],
+                             keep_unlicensed: bool = False) -> List[Package]:
+        """Filter out packages with non-OSS licenses.
+
+        When keep_unlicensed is True, packages with no license are retained
+        rather than dropped, so the caller can surface them as NOASSERTION.
+        This is used for machine-readable output such as SBOMs, where silently
+        omitting a component would under-report the dependency set.
+        """
         oss_packages = []
         
         licenses_dir = Path(__file__).parent / "data" / "licenses"
@@ -132,10 +139,14 @@ class NoticeFormatter:
         valid_spdx_lower = {lid.lower(): lid for lid in valid_spdx_ids}
         
         for package in packages:
-            # Skip packages without licenses
+            # Packages without a license are dropped from human-facing notices,
+            # but retained for machine-readable output so they are not silently
+            # lost (they are surfaced as NOASSERTION by the caller).
             if not package.licenses:
+                if keep_unlicensed:
+                    oss_packages.append(package)
                 continue
-            
+
             # Check if any license is non-OSS
             is_non_oss = False
             for license_info in package.licenses:
@@ -177,8 +188,11 @@ class NoticeFormatter:
                 else:
                     license_key = unique_licenses[0]
                 groups[license_key].append(package)
-            # Skip packages without licenses - don't add to any group
-        
+            else:
+                # Surface unlicensed packages explicitly under NOASSERTION so
+                # they are never silently dropped from the output.
+                groups["NOASSERTION"].append(package)
+
         # Sort groups by license ID
         return dict(sorted(groups.items()))
     
@@ -186,8 +200,9 @@ class NoticeFormatter:
                      include_copyright: bool = True, include_license_text: bool = True,
                      license_texts: Optional[Dict[str, str]] = None) -> str:
         """Format packages as JSON output."""
-        # Filter out non-OSS packages
-        oss_packages = self._filter_oss_packages(packages)
+        # Filter out non-OSS packages, but keep unlicensed ones so no component
+        # is silently dropped from machine-readable output (SBOMs).
+        oss_packages = self._filter_oss_packages(packages, keep_unlicensed=True)
         
         result = {
             "metadata": {
@@ -234,7 +249,7 @@ class NoticeFormatter:
                     "name": pkg.name,
                     "version": pkg.version,
                     "purl": pkg.purl,
-                    "licenses": [lic.id for lic in pkg.licenses],
+                    "licenses": [lic.spdx_id for lic in pkg.licenses] or ["NOASSERTION"],
                     "homepage": pkg.metadata.get("homepage") if pkg.metadata else None,
                     "source_path": pkg.source_path
                 }

--- a/tests/unit/test_formatter_json.py
+++ b/tests/unit/test_formatter_json.py
@@ -1,0 +1,77 @@
+"""Tests for JSON formatter output, covering the SBOM completeness guarantee
+that unlicensed packages are never silently dropped (issue #30)."""
+
+import json
+
+import pytest
+
+from purl2notices.formatter import NoticeFormatter
+from purl2notices.models import Package, License
+
+
+@pytest.fixture
+def formatter():
+    return NoticeFormatter()
+
+
+def _mit(name, version):
+    return Package(name=name, version=version, purl=f"pkg:npm/{name}@{version}",
+                   licenses=[License(spdx_id="MIT", name="MIT", text="")])
+
+
+def _unlicensed(name, version):
+    return Package(name=name, version=version, purl=f"pkg:npm/{name}@{version}")
+
+
+class TestJsonUnlicensedNotDropped:
+    """An unlicensed package must appear in JSON output, marked NOASSERTION."""
+
+    def test_grouped_output_surfaces_unlicensed_under_noassertion(self, formatter):
+        packages = [_mit("cookie", "1.1.1"), _unlicensed("picocolors", "1.1.1")]
+
+        result = json.loads(formatter.format(packages, format_type="json"))
+
+        assert result["metadata"]["total_packages"] == 2
+        groups = {g["id"]: [p["name"] for p in g["packages"]]
+                  for g in result["licenses"]}
+        assert groups["MIT"] == ["cookie"]
+        assert groups["NOASSERTION"] == ["picocolors"]
+
+    def test_ungrouped_output_marks_unlicensed_noassertion(self, formatter):
+        packages = [_mit("cookie", "1.1.1"), _unlicensed("picocolors", "1.1.1")]
+
+        result = json.loads(
+            formatter.format(packages, format_type="json", group_by_license=False)
+        )
+
+        by_name = {p["name"]: p["licenses"] for p in result["packages"]}
+        assert by_name["cookie"] == ["MIT"]
+        assert by_name["picocolors"] == ["NOASSERTION"]
+
+    def test_all_unlicensed_still_reported(self, formatter):
+        packages = [_unlicensed("a", "1.0.0"), _unlicensed("b", "2.0.0")]
+
+        result = json.loads(formatter.format(packages, format_type="json"))
+
+        assert result["metadata"]["total_packages"] == 2
+        groups = {g["id"]: [p["name"] for p in g["packages"]]
+                  for g in result["licenses"]}
+        assert sorted(groups["NOASSERTION"]) == ["a", "b"]
+
+
+class TestFilterOssPackages:
+    """The keep_unlicensed flag governs whether unlicensed packages survive."""
+
+    def test_default_drops_unlicensed(self, formatter):
+        packages = [_mit("cookie", "1.1.1"), _unlicensed("picocolors", "1.1.1")]
+
+        kept = formatter._filter_oss_packages(packages)
+
+        assert [p.name for p in kept] == ["cookie"]
+
+    def test_keep_unlicensed_retains_them(self, formatter):
+        packages = [_mit("cookie", "1.1.1"), _unlicensed("picocolors", "1.1.1")]
+
+        kept = formatter._filter_oss_packages(packages, keep_unlicensed=True)
+
+        assert sorted(p.name for p in kept) == ["cookie", "picocolors"]


### PR DESCRIPTION
## Problem

Issue #30: a package whose license cannot be classified disappears from the SBOM with no warning, so `packages_count` under-reports the real dependency set.

An earlier PR made the CycloneDX cache path always emit NOASSERTION, but that is not the path the SBOM tooling uses. The `mcp-semclone generate_sbom` tool consumes purl2notices `-f json` output, and that output still dropped unlicensed packages.

## Root cause

The JSON formatter builds its output by grouping packages under license keys, and dropped any package with no license in two places:

- `_filter_oss_packages` skipped packages with no licenses before anything else ran.
- `_group_by_license` skipped them again.

Because mcp-semclone discovers packages by walking those license groups, a package that landed in no group was never seen, hence the silent drop of picocolors.

## Fix

Retain unlicensed packages in the JSON output and surface them under a `NOASSERTION` group so every component is represented:

- `_filter_oss_packages` takes a `keep_unlicensed` flag (default False), and `_format_json` passes it as True.
- `_group_by_license` puts packages with no license under a `NOASSERTION` key instead of skipping them.

Human-facing text and HTML notices are unchanged. They still omit packages without a license, which is the intended behavior for an attribution file.

This also closes the loop with mcp-semclone: its existing loop already iterates every license group, so once a `NOASSERTION` group is present it picks those packages up automatically.

While here, fixed a latent crash in the ungrouped JSON branch, which referenced a non-existent `License.id` attribute. It now uses `spdx_id` and falls back to `NOASSERTION`.

## Verification

With a mix of licensed and unlicensed packages, the unlicensed one now appears under `NOASSERTION` in both grouped and ungrouped JSON, and `total_packages` counts it.

Added regression tests for the grouped and ungrouped JSON paths, the all-unlicensed case, and the `keep_unlicensed` flag. Full suite: 102 passing.

## Out of scope

The invalid over-matched SPDX ids (`"MIT, MIT-or-later"`, `"BSD-2-Clause, BSD-3-Clause"`) and canonical ISC-text recognition are in the osslili classifier and are tracked separately.

Addresses #30.
